### PR TITLE
remove gulp-util dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,7 @@
 var jsonlint = require( 'json-lint' );
 
 // Gulp
-var gutil = require('gulp-util');
-var PluginError = gutil.PluginError;
+var PluginError = require('plugin-error');
 var map = require('map-stream');
 
 "use strict";

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "jsonlint"
   ],
   "dependencies": {
+    "json-lint": "~0.1.0",
     "map-stream": "~0.1.0",
-    "gulp-util": "~3.0.3",
-    "json-lint": "~0.1.0"
+    "plugin-error": "^0.1.2"
   },
   "analyze": true,
   "devDependencies": {},

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -1,6 +1,5 @@
 // Simple Gulpfile
 var gulp = require('gulp');
-var gutil = require('gulp-util');
 
 // Gulp plugins
 var jsonlint = require('../index');


### PR DESCRIPTION
As [advised](https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5) by the Gulp maintainers, this PR removes the dependency on `gulp-util`. 